### PR TITLE
Replace direct usage of `env()` with `config()`

### DIFF
--- a/config/https.php
+++ b/config/https.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    /*
+     * LaravelHTTPS forces the URL scheme in Laravel to use the HTTPS prefix for all links generated using url() and route(). 
+     * That mean that all your links can be converted to use HTTPS just by installing LaravelHTTPS.
+     */
+    'force' => env('HTTPS', false),
+];

--- a/src/Http/Middleware/ForceHttps.php
+++ b/src/Http/Middleware/ForceHttps.php
@@ -15,7 +15,7 @@ class ForceHttps
      */
     public function handle($request, Closure $next)
     {
-        if (env('HTTPS') === true and
+        if (config('https.force') === true and
             (
                 !$request->secure() or
                 (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'http')

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -8,13 +8,24 @@ class ServiceProvider extends Provider
 {
     public function boot()
     {
-       //
+        $this->publishes([
+            $this->getConfigPath() => config_path('https.php'),
+        ], 'config');
+
+        if (config('https.force')) {
+            $this->app['url']->forceScheme('https');
+        }
     }
 
     public function register()
     {
-        if (env('HTTPS')) {
-            $this->app['url']->forceScheme('https');
-        }
+        $this->mergeConfigFrom(
+            $this->getConfigPath(), 'https'
+        );
+    }
+
+    private function getConfigPath()
+    {
+        return dirname(__DIR__, 2).'/config/https.php';
     }
 }


### PR DESCRIPTION
This allows compatibility with projects that use `config:cache`.

See https://laravel.com/docs/5.4/configuration#configuration-caching